### PR TITLE
Don't check if package already exists when `publish: false`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,12 +45,12 @@ runs:
                 then
                   TARGET_URL="${{ inputs.hackageServer }}/packages/upload";
                   DOCS_URL="${{ inputs.hackageServer }}/package/$PACKAGE_NAME/docs"
+                  HACKAGE_STATUS=$(curl --header "${HACKAGE_AUTH_HEADER}" --silent --head -w %{http_code} -XGET --anyauth ${{ inputs.hackageServer }}/package/${PACKAGE_NAME} -o /dev/null)
                 else
                   TARGET_URL="${{ inputs.hackageServer }}/packages/candidates";
                   DOCS_URL="${{ inputs.hackageServer }}/package/$PACKAGE_NAME/candidate/docs"
+                  HACKAGE_STATUS=404
               fi
-
-              HACKAGE_STATUS=$(curl --header "${HACKAGE_AUTH_HEADER}" --silent --head -w %{http_code} -XGET --anyauth ${{ inputs.hackageServer }}/package/${PACKAGE_NAME} -o /dev/null)
 
               if [ "$HACKAGE_STATUS" = "404" ]; then
                 echo "Uploading ${PACKAGE_NAME} to ${TARGET_URL}"


### PR DESCRIPTION
Hackage accepts any package candidates, even if a published package with the same version already exists.  With this PR a user can make use of this functionality if s/he chooses so.