### PR TITLE
Rewrite action with github-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A GitHub action for publishing packages and documentation to Hackage
 * `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
 
 * `publish` (optional): When false, uploads as a candidate.
-    * Defaults to `true`
-    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. You likely want to set this to `false`
+    * Defaults to `false`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `true`
 
 * `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,44 @@
 # hackage-publish
+
 A GitHub action for publishing packages and documentation to Hackage
 
-## Usage Examples
+## Inputs
 
-This step publishes packages and documentation as candidates on Hackage using the specified authentication token.  You can generate an authentication token on [your Hackage account managment page](http://hackage.haskell.org/users/account-management).
+* `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
+
+* `publish` (optional): When false, uploads as a candidate.
+    * Defaults to `true`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. You likely want to set this to `false`
+
+* `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
+
+* `docsPath` (optional): The path that contains packages' documentation tarballs.
+    * If not set, does not upload documentation separately
+
+* `hackageServer` (optional): The URL of the Hackage server to upload to (e.g. for self-hosted Hackage instances)
+
+## Outputs
+
+N/A
+
+## Example
 
 ```yaml
 - uses: haskell-actions/hackage-publish@v1
   with:
     hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-    packagesPath: ${{ runner.temp }}/packages
-    docsPath: ${{ runner.temp }}/docs
-    publish: false
 ```
 
-`docsPath` parameter is optional and the action will not try uploading documentation when it is not specified.
-When `docsPath` is specified, but doesn't contain documentation for one or many packages in `packagePath`, 
-these packages are uploaded without documentation. Missing documentation never results into an execution error.
-    
-To publish to a custom/private Hackage, specify `hackageServer` parameter to the custom/private Hackage server URI
-    
+One particularly useful workflow is to be able to use the hackage token associated with the GitHub user running the workflow. This allows multiple maintainers to use their own tokens and not have to share one user's token.
+
 ```yaml
+- name: Load Hackage token secret name
+  id: hackage_token_secret
+  run: |
+    USERNAME="$(echo "${GITHUB_ACTOR}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+    echo "name=HACKAGE_TOKEN_${USERNAME}" >> "${GITHUB_OUTPUT}"
+
 - uses: haskell-actions/hackage-publish@v1
   with:
-    hackageServer: ${{ secrets.HACKAGE_SERVER }}
-    hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-    packagesPath: ${{ runner.temp }}/packages
-    publish: true
+    hackageToken: ${{ secrets[steps.hackage_token_secret.outputs.name] }}
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A GitHub action for publishing packages and documentation to Hackage
 
 * `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
 
-* `publish` (optional): When false, uploads as a candidate.
-    * Defaults to `false`
-    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `true`
+* `candidate` (optional): When true, uploads as a candidate.
+    * Defaults to `true`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `false`
 
 * `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
 

--- a/action.yml
+++ b/action.yml
@@ -33,45 +33,22 @@ inputs:
 runs:
   using: 'composite'
   steps:
-
-    - name: Publish packages
+    -
+      uses: actions/setup-node@v6
+    -
+      run: npm install node-fetch
+      working-directory: ${{ github.action_path }}
       shell: bash
-      run: |
-          HACKAGE_AUTH_HEADER="Authorization: X-ApiKey ${{ inputs.hackageToken }}"
+    -
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const fetchModule = await import(
+            '${{ github.action_path }}/node_modules/node-fetch/src/index.js'
+          )
+          const { fileFrom } = fetchModule
 
-          for PACKAGE_TARBALL in $(find "${{ inputs.packagesPath }}" -maxdepth 1 -name "*.tar.gz"); do
-              PACKAGE_NAME=$(basename ${PACKAGE_TARBALL%.*.*})
-              
-              if [ "${{ inputs.publish }}" == "true" ];
-                then
-                  TARGET_URL="${{ inputs.hackageServer }}/packages/upload";
-                  PACKAGE_URL="${{ inputs.hackageServer }}/package/$PACKAGE_NAME"
-                  HACKAGE_STATUS=$(curl --header "${HACKAGE_AUTH_HEADER}" --silent --head -w %{http_code} -XGET --anyauth ${{ inputs.hackageServer }}/package/${PACKAGE_NAME} -o /dev/null)
-                else
-                  TARGET_URL="${{ inputs.hackageServer }}/packages/candidates";
-                  PACKAGE_URL="${{ inputs.hackageServer }}/package/$PACKAGE_NAME/candidate"
-                  HACKAGE_STATUS=404
-              fi
-
-              DOCS_URL="$PACKAGE_URL/docs"
-
-              if [ "$HACKAGE_STATUS" = "404" ]; then
-                echo "Uploading ${PACKAGE_NAME} to ${TARGET_URL}"
-                curl -X POST -f --header "${HACKAGE_AUTH_HEADER}" ${TARGET_URL} -F "package=@$PACKAGE_TARBALL"
-                echo "Uploaded ${PACKAGE_URL}"
-
-                DOC_FILE_NAME="${{ inputs.docsPath }}/${PACKAGE_NAME}-docs.tar.gz"
-                if [ -n "${{ inputs.docsPath }}" ] && [ -f "$DOC_FILE_NAME" ]; then
-                  echo "Uploading documentation for ${PACKAGE_NAME} to ${DOCS_URL}"
-                  curl -X PUT \
-                    -H 'Content-Type: application/x-tar' \
-                    -H 'Content-Encoding: gzip' \
-                    -H "${HACKAGE_AUTH_HEADER}" \
-                    --data-binary "@$DOC_FILE_NAME" \
-                    "$DOCS_URL"
-                fi
-
-              else
-                echo "Package ${PACKAGE_NAME}" already exists on Hackage.
-              fi
-          done
+          // https://github.com/actions/toolkit/issues/1124#issuecomment-1305836110
+          const inputs = ${{ toJSON(inputs) }}
+          const script = require('${{ github.action_path }}/upload-hackage.js')
+          await script({ inputs, core, glob, fetch: fetchModule.default, require, fileFrom })

--- a/action.yml
+++ b/action.yml
@@ -21,12 +21,12 @@ inputs:
     default: 'false'
 
   packagesPath:
-    description: 'Path that contains packages tarbals'
+    description: 'Path that contains package tarballs'
     required: false
     default: dist-newstyle/sdist/
 
   docsPath:
-    description: 'Path that contains packages documentation tarbals'
+    description: 'Path that contains package documentation tarballs'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Authentication token for Hackage'
     required: true
 
-  publish:
-    description: 'A flag indicating whether to publish the release on Hackage. Uploads a release candidate if set to false'
+  candidate:
+    description: 'Whether to upload the package as a candidate'
     required: false
-    default: 'false'
+    default: 'true'
 
   packagesPath:
     description: 'Path that contains package tarballs'

--- a/upload-hackage.js
+++ b/upload-hackage.js
@@ -1,0 +1,59 @@
+module.exports = async ({ inputs, core, glob, fetch, require, fileFrom }) => {
+  const fs = require('fs')
+  const path = require('path')
+
+  const auth = `X-ApiKey ${inputs.hackageToken}`
+  const uploadUrlSuffix = inputs.candidate ? '/candidates' : '/upload'
+  const packageUrlSuffix = inputs.candidate ? '/candidate' : ''
+  const checkExists = !inputs.candidate
+
+  const archivePaths = await glob.create(`${inputs.packagesPath}/*.tar.gz`).then((g) => g.glob())
+  for (const archivePath of archivePaths) {
+    const name = path.basename(archivePath, '.tar.gz')
+    const uploadUrl = `${inputs.hackageServer}/packages${uploadUrlSuffix}`
+    const packageUrl = `${inputs.hackageServer}/packages/${name}${packageUrlSuffix}`
+
+    // check if package already uploaded
+    if (checkExists) {
+      const existsResp = await fetch(packageUrl, { method: 'HEAD' })
+      if (existsResp.status != 404) {
+        core.info(`Package "${name}" already exists on Hackage`)
+        continue
+      }
+    }
+
+    // upload package
+    core.info(`Uploading package "${name}" to ${uploadUrl}`)
+    const uploadBody = new FormData()
+    const archiveFile = await fileFrom(archivePath, 'application/octet-stream')
+    uploadBody.set('package', archiveFile)
+    const uploadResp = await fetch(uploadUrl, {
+      method: 'POST',
+      headers: { 'Authorization': auth },
+      body: uploadBody,
+    })
+    if (uploadResp.status >= 400) {
+      const uploadRespBody = await uploadResp.text()
+      throw new Error(`Failed to upload package "${name}": ${uploadRespBody}`)
+    }
+    core.info(`Successfully uploaded ${packageUrl}`)
+
+    // upload docs
+    const docsArchive = `${inputs.docsPath}/${name}-docs.tar.gz`
+    const docsUrl = `${packageUrl}/docs`
+    if (inputs.docsPath && fs.existsSync(docsArchive)) {
+      core.info(`Uploading documentation for "${name}" to ${docsUrl}`)
+      const docsBody = await fetch.blobFrom(docsArchive, 'application/octet-stream')
+      await fetch(docsUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/x-tar',
+          'Content-Encoding': 'gzip',
+          'Authorization': auth,
+        },
+        body: docsBody,
+      })
+      core.info(`Successfully uploaded ${docsUrl}`)
+    }
+  }
+}


### PR DESCRIPTION
Javascript is much better than bash, with proper error mechanisms, better variables, better for-loops, etc. This also lets us use all the utilities normal GitHub actions can use, via [actions/github-script](https://github.com/actions/github-script), taking advantage of the whole ecosystem.

Tested here: https://github.com/fourmolu/fourmolu/actions/runs/4624388970/jobs/8203029673

## PR Stack

* https://github.com/haskell-actions/hackage-publish/pull/14
* https://github.com/haskell-actions/hackage-publish/pull/15
* https://github.com/haskell-actions/hackage-publish/pull/16
* 👉  https://github.com/haskell-actions/hackage-publish/pull/8