### PR TITLE
Change `publish` => `candidate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A GitHub action for publishing packages and documentation to Hackage
 * `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
 
 * `publish` (optional): When false, uploads as a candidate.
-    * Defaults to `true`
-    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. You likely want to set this to `false`
+    * Defaults to `false`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `true`
 
 * `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,44 @@
 # hackage-publish
+
 A GitHub action for publishing packages and documentation to Hackage
 
-## Usage Examples
+## Inputs
 
-This step publishes packages and documentation as candidates on Hackage using the specified authentication token.  You can generate an authentication token on [your Hackage account managment page](http://hackage.haskell.org/users/account-management).
+* `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
+
+* `publish` (optional): When false, uploads as a candidate.
+    * Defaults to `true`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. You likely want to set this to `false`
+
+* `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
+
+* `docsPath` (optional): The path that contains packages' documentation tarballs.
+    * If not set, does not upload documentation separately
+
+* `hackageServer` (optional): The URL of the Hackage server to upload to (e.g. for self-hosted Hackage instances)
+
+## Outputs
+
+N/A
+
+## Example
 
 ```yaml
 - uses: haskell-actions/hackage-publish@v1
   with:
     hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-    packagesPath: ${{ runner.temp }}/packages
-    docsPath: ${{ runner.temp }}/docs
-    publish: false
 ```
 
-`docsPath` parameter is optional and the action will not try uploading documentation when it is not specified.
-When `docsPath` is specified, but doesn't contain documentation for one or many packages in `packagePath`, 
-these packages are uploaded without documentation. Missing documentation never results into an execution error.
-    
-To publish to a custom/private Hackage, specify `hackageServer` parameter to the custom/private Hackage server URI
-    
+One particularly useful workflow is to be able to use the hackage token associated with the GitHub user running the workflow. This allows multiple maintainers to use their own tokens and not have to share one user's token.
+
 ```yaml
+- name: Load Hackage token secret name
+  id: hackage_token_secret
+  run: |
+    USERNAME="$(echo "${GITHUB_ACTOR}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+    echo "name=HACKAGE_TOKEN_${USERNAME}" >> "${GITHUB_OUTPUT}"
+
 - uses: haskell-actions/hackage-publish@v1
   with:
-    hackageServer: ${{ secrets.HACKAGE_SERVER }}
-    hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-    packagesPath: ${{ runner.temp }}/packages
-    publish: true
+    hackageToken: ${{ secrets[steps.hackage_token_secret.outputs.name] }}
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A GitHub action for publishing packages and documentation to Hackage
 
 * `hackageToken` (required): An auth token from Hackage, which can be generated at `https://hackage.haskell.org/user/$USERNAME/manage`
 
-* `publish` (optional): When false, uploads as a candidate.
-    * Defaults to `false`
-    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `true`
+* `candidate` (optional): When true, uploads as a candidate.
+    * Defaults to `true`
+    * WARNING: Because Hackage uploads are permanent, it's usually not a good idea to do irreversible actions in an automatic pipeline. If you're absolutely sure you want to skip the candidate step, set this to `false`
 
 * `packagesPath` (optional): The path that contains package tarballs (defaults to `dist-newstyle/sdist/`)
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Authentication token for Hackage'
     required: true
 
-  publish:
-    description: 'A flag indicating whether to publish the release on Hackage. Uploads a release candidate if set to false'
+  candidate:
+    description: 'Whether to upload the package as a candidate'
     required: false
-    default: 'false'
+    default: 'true'
 
   packagesPath:
     description: 'Path that contains packages tarballs'

--- a/action.yml
+++ b/action.yml
@@ -21,12 +21,12 @@ inputs:
     default: 'false'
 
   packagesPath:
-    description: 'Path that contains packages tarbals'
+    description: 'Path that contains packages tarballs'
     required: false
     default: dist-newstyle/sdist/
 
   docsPath:
-    description: 'Path that contains packages documentation tarbals'
+    description: 'Path that contains packages documentation tarballs'
     required: false
     default: ''
 


### PR DESCRIPTION
Broken out from #8 

Change `publish` input to `candidate`. This makes the intent of the option clearer

## PR Stack

* https://github.com/haskell-actions/hackage-publish/pull/14
* https://github.com/haskell-actions/hackage-publish/pull/15
* 👉  https://github.com/haskell-actions/hackage-publish/pull/16
* https://github.com/haskell-actions/hackage-publish/pull/8